### PR TITLE
Migrate documentation from old wiki

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,77 @@
+[[zentimestamp-plugin-changelog]]
+= Changelog
+
+== Release 4.2 (July 25, 2015)
+
+=== Fixed
+- Fix https://issues.jenkins-ci.org/browse/JENKINS-26958[JENKINS-26958]: workflow plugin compatibility
+
+== Release 4.1 (May 24, 2015)
+
+=== Removed
+- Commented out logging statement
+
+== Release 4.0 (April 07, 2015)
+
+=== Fixed
+- Fix https://issues.jenkins-ci.org/browse/JENKINS-26626[JENKINS-26626] - Switch to use BUILD_TIMESTAMP environment variable and make it compatible with Jenkins 1.597+
+
+== Release 3.3 (May 16, 2013)
+
+=== Fixed
+- Fix https://issues.jenkins-ci.org/browse/JENKINS-17975[JENKINS-17975] - SCM polling stops to work if the previously used build node no longer exists
+
+== Release 3.2 (March 10, 2012)
+
+=== Added
+- Make it compatible to MatrixProject
+
+== Release 3.1 (March 07, 2012)
+
+=== Added
+- Make it compatible to https://wiki.jenkins.io/display/JENKINS/EnvInject+Plugin[envinject jenkins plugin] (Remove `+RunListener+` and add an `+EnvironmentContributor+`).
+
+=== Fixed
+- Fix https://issues.jenkins-ci.org/browse/JENKINS-12694[JENKINS-12694] - Zentimestamp plugin v3.0 no longer compatible with hudson.
+
+== Release 3.0 (December 21, 2011)
+
+=== Added
+- Add the ability to change the date format at node level
+
+== Release 2.2 (March 1, 2011)
+
+=== Changed
+- Change UI labels from Hudson to Jenkins
+
+== Release 2.1 (February 19, 2011)
+
+=== Changed
+- Updated over new Jenkins 1.397 API and metadata
+
+== Release 2.0.1 (July 02, 2010)
+
+=== Fixed
+- Fixed regression for backward compatibility with zentimestamp 1.2
+
+== Release 2.0 (June 20, 2010)
+
+=== Added
+- The plugin is now a job property that enables users to change the `+BUILD_ID+` variable from Hudson publishers too
+
+== Release 1.2 (February 10, 2009)
+
+=== Changed
+- Upgraded to new Hudson API 
+
+=== Added
+- Added integration tests
+
+== Release 1.1 (June 10, 2009)
+
+=== Fixed
+- Fixed Help 404 error with Hudson 1.3xx
+
+== Release 1.0 (August 12, 2008)
+
+Initial release

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,29 @@
+[[zentimestamp-plugin]]
+= Zentimestamp Plugin
+
+link:https://github.com/jenkinsci/zentimestamp-plugin/graphs/contributors[image:https://img.shields.io/github/contributors/jenkinsci/zentimestamp-plugin.svg[contributors]]
+link:https://plugins.jenkins.io/zentimestamp[image:https://img.shields.io/jenkins/plugin/v/zentimestamp.svg[plugin]]
+
+*This plugin is up for adoption.* Want to help improve this plugin?
+https://wiki.jenkins.io/display/JENKINS/Adopt+a+Plugin[Click here to
+learn more]!
+
+[[zentimestamp-plugin-description]]
+== Description
+
+From Jenkins 1.597, the plugin adds the Jenkins `+BUILD_TIMESTAMP+`
+variable to the Configure System page of Manage Jenkins.  Note: you must
+activate the Global Property! +
+You must specify a
+http://java.sun.com/javase/6/docs/api/java/text/SimpleDateFormat.html[java.text.SimpleDateFormat]
+pattern such as the value '`+yyyyMMddHHmmss+`'.
+
+[[zentimestamp-plugin-features]]
+== Features
+
+* Export a `+BUILD_TIMESTAMP+` variable to the Jenkins instance (all
+jobs on all slaves will be impacted).
+* Export a `+BUILD_TIMESTAMP+` variable to the slave (all jobs on this
+slave will be impacted).
+* Export a `+BUILD_TIMESTAMP+` variable to the job (only the job will be
+impacted)

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
     <version>4.3-SNAPSHOT</version>
     <name>Jenkins Zentimestamp plugin</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Zentimestamp+Plugin</url>
+    <url>https://github.com/jenkinsci/zentimestamp-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
Migrating the documentation from the old wiki for the [documentation
migration
initiative](https://jenkins-wiki-exporter.jenkins.io/progress).
